### PR TITLE
Prevent word splitting from command line arguments

### DIFF
--- a/nginx-cache-purge
+++ b/nginx-cache-purge
@@ -79,4 +79,4 @@ function nginx_cache_purge_item() {
 } # nginx_cache_purge_item
 
 ## Try to purge the given item from the cache.
-nginx_cache_purge_item $1 $2
+nginx_cache_purge_item "$1" "$2"


### PR DESCRIPTION
arguments with spaces got split when being passed to `nginx_cache_purge_item`
